### PR TITLE
Client: don't call `shutdown_send` on the client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 0.2.1 2020-05-16
 --------------
 
+- gluten-lwt, gluten-async, gluten-lwt-unix, gluten-mirage: never call
+  `shutdown` with `SHUTDOWN_SEND`. This is especially important on the client,
+  where sending a `FIN` packet might cause the other end to shutdown the
+  connection without sending back a response
+  ([#10](https://github.com/anmonteiro/gluten/pull/10))
+
+0.2.1 2020-05-16
+--------------
+
 - gluten-mirage: Add a Mirage runtime
   ([#5](https://github.com/anmonteiro/gluten/pull/5))
 - gluten: Remove dependency on httpaf

--- a/async/gluten_async.ml
+++ b/async/gluten_async.ml
@@ -242,8 +242,9 @@ module Unix_io :
 
   let close socket =
     let fd = Socket.fd socket in
-    if not (Fd.is_closed fd) then
-      Fd.close fd
+    if not (Fd.is_closed fd) then (
+      Socket.shutdown socket `Both;
+      Fd.close fd)
     else
       Deferred.unit
 end

--- a/async/gluten_async_intf.ml
+++ b/async/gluten_async_intf.ml
@@ -50,8 +50,6 @@ module type IO = sig
     -> Faraday.bigstring Faraday.iovec list
     -> [ `Closed | `Ok of int ] Deferred.t
 
-  val shutdown_send : socket -> unit
-
   val shutdown_receive : socket -> unit
 
   val close : socket -> unit Deferred.t

--- a/async/ssl_io_dummy.ml
+++ b/async/ssl_io_dummy.ml
@@ -46,8 +46,6 @@ module Io :
 
   let writev _ _iovecs = failwith "Ssl not available"
 
-  let shutdown_send _ = failwith "Ssl not available"
-
   let shutdown_receive _ = failwith "Ssl not available"
 
   let close _ = failwith "Ssl not available"

--- a/async/ssl_io_real.ml
+++ b/async/ssl_io_real.ml
@@ -81,8 +81,6 @@ module Io :
    * Note: In the SSL / TLS runtimes we can't just shutdown one part of the
    * full-duplex connection, as both sides must know that the underlying TLS
    * conection is closing. *)
-  let shutdown_send _ = ()
-
   let shutdown_receive _ = ()
 
   let close { reader; writer; closed } =

--- a/lwt-unix/gluten_lwt_unix.ml
+++ b/lwt-unix/gluten_lwt_unix.ml
@@ -74,8 +74,6 @@ module Io :
       | Unix.Unix_error (Unix.ENOTCONN, _, _) ->
         ()
 
-  let shutdown_send socket = shutdown socket Unix.SHUTDOWN_SEND
-
   let shutdown_receive socket = shutdown socket Unix.SHUTDOWN_RECEIVE
 end
 

--- a/lwt-unix/gluten_lwt_unix.ml
+++ b/lwt-unix/gluten_lwt_unix.ml
@@ -44,7 +44,11 @@ module Io :
     | Closed ->
       Lwt.return_unit
     | _ ->
-      Lwt.catch (fun () -> Lwt_unix.close socket) (fun _exn -> Lwt.return_unit)
+      Lwt.catch
+        (fun () ->
+          Lwt_unix.shutdown socket SHUTDOWN_ALL;
+          Lwt_unix.close socket)
+        (fun _exn -> Lwt.return_unit)
 
   let read socket bigstring ~off ~len =
     Lwt.catch

--- a/lwt-unix/ssl_io_dummy.ml
+++ b/lwt-unix/ssl_io_dummy.ml
@@ -43,8 +43,6 @@ struct
 
   let writev _ _iovecs = Lwt.fail_with "Ssl not available"
 
-  let shutdown_send _ = failwith "Ssl not available"
-
   let shutdown_receive _ = failwith "Ssl not available"
 
   let close _ = failwith "Ssl not available"

--- a/lwt-unix/ssl_io_real.ml
+++ b/lwt-unix/ssl_io_real.ml
@@ -100,8 +100,6 @@ struct
    * Note: In the SSL / TLS runtimes we can't just shutdown one part of the
    * full-duplex connection, as both sides must know that the underlying TLS
    * conection is closing. *)
-  let shutdown_send _ssl = ()
-
   let shutdown_receive _ssl = ()
 end
 

--- a/lwt-unix/tls_io_dummy.ml
+++ b/lwt-unix/tls_io_dummy.ml
@@ -43,8 +43,6 @@ struct
 
   let writev _ _iovecs = Lwt.fail_with "Tls not available"
 
-  let shutdown_send _ = failwith "Tls not available"
-
   let shutdown_receive _ = failwith "Tls not available"
 
   let close _ = Lwt.fail_with "Tls not available"

--- a/lwt-unix/tls_io_real.ml
+++ b/lwt-unix/tls_io_real.ml
@@ -75,8 +75,6 @@ struct
         | exn ->
           Lwt.fail exn)
 
-  let shutdown_send _tls = ()
-
   let shutdown_receive _tls = ()
 end
 

--- a/lwt/gluten_lwt.ml
+++ b/lwt/gluten_lwt.ml
@@ -141,7 +141,6 @@ module IO_loop = struct
           Lwt.return_unit
         | `Close _ ->
           Lwt.wakeup_later notify_write_loop_exited ();
-          Io.shutdown_send socket;
           Lwt.return_unit
       in
       Lwt.async (fun () ->

--- a/lwt/gluten_lwt_intf.ml
+++ b/lwt/gluten_lwt_intf.ml
@@ -48,8 +48,6 @@ module type IO = sig
     -> Faraday.bigstring Faraday.iovec list
     -> [ `Closed | `Ok of int ] Lwt.t
 
-  val shutdown_send : socket -> unit
-
   val shutdown_receive : socket -> unit
 
   val close : socket -> unit Lwt.t

--- a/mirage/gluten_mirage.ml
+++ b/mirage/gluten_mirage.ml
@@ -42,8 +42,6 @@ module Make_IO (Flow : Mirage_flow.S) :
 
   let shutdown_receive flow = Lwt.async (fun () -> shutdown flow)
 
-  let shutdown_send flow = Lwt.async (fun () -> shutdown flow)
-
   let close = shutdown
 
   let read flow bigstring ~off ~len:_ =

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,7 +25,7 @@ in
 
       gluten-lwt = buildGluten {
         pname = "gluten-lwt";
-        propagatedBuildInputs = [ gluten lwt4 ];
+        propagatedBuildInputs = [ gluten lwt ];
       };
 
       gluten-lwt-unix = buildGluten {

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/acbabb0.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/93d0d8b.tar.gz;
 
 in
 

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -3,7 +3,7 @@
 let
   overlays =
     builtins.fetchTarball
-      https://github.com/anmonteiro/nix-overlays/archive/0222c505.tar.gz;
+      https://github.com/anmonteiro/nix-overlays/archive/acbabb0.tar.gz;
 
 in
 


### PR DESCRIPTION
Calling `shutdown_send` on a client connection that hasn't received a
response may cause the other end to send a TCP FIN instead of the
response, for connections that aren't persistent.

TODO:
- [x] changelog entry
