### PR TITLE
Bigstring is now under core.bigstring_unix

### DIFF
--- a/async/gluten_async.ml
+++ b/async/gluten_async.ml
@@ -221,14 +221,14 @@ module Unix_io :
           (Fd.syscall fd ~nonblocking:true (fun file_descr ->
                Unix.Syscall_result.Int.ok_or_unix_error_exn
                  ~syscall_name:"read"
-                 (Bigstring.read_assume_fd_is_nonblocking
+                 (Bigstring_unix.read_assume_fd_is_nonblocking
                     file_descr
                     bigstring
                     ~pos:off
                     ~len)))
       else
         Fd.syscall_in_thread fd ~name:"read" (fun file_descr ->
-            Bigstring.read file_descr bigstring ~pos:off ~len)
+            Bigstring_unix.read file_descr bigstring ~pos:off ~len)
         >>= fun result -> finish fd buffer result
     in
     go fd bigstring

--- a/gluten-async.opam
+++ b/gluten-async.opam
@@ -15,6 +15,7 @@ depends: [
   "gluten" {= version}
   "faraday-async" {>= "0.7.2"}
   "async" { >= "v0.14.0" }
+  "core" { >= "v0.14.0" }
 ]
 depopts: ["async_ssl"]
 synopsis: "Async runtime for gluten"

--- a/gluten-async.opam
+++ b/gluten-async.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.0"}
   "gluten" {= version}
-  "faraday-async"
+  "faraday-async" {>= "0.7.2"}
   "async" { >= "v0.14.0" }
 ]
 depopts: ["async_ssl"]

--- a/gluten-async.opam
+++ b/gluten-async.opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.0"}
   "gluten" {= version}
   "faraday-async"
-  "async"
+  "async" { >= "v0.14.0" }
 ]
 depopts: ["async_ssl"]
 synopsis: "Async runtime for gluten"


### PR DESCRIPTION
Bigstring module has moved to its own library in Core 0.14

Reference: https://github.com/janestreet/core/blob/102863ed50a4e679efea97303d38bd0cceb9eacb/bigstring_unix/src/dune

Note: a new version of faraday-async will also be needed before this can work. Leaving a PR open as a reminder to me to follow up whenever a new faraday-async version hits opam.