### PR TITLE
gluten-mirage: fix read and writev functions

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-profile = sparse
+profile = default
 break-cases = nested
 break-fun-decl = smart
 cases-exp-indent = 2

--- a/mirage/dune
+++ b/mirage/dune
@@ -1,6 +1,6 @@
 (library
  (name gluten_mirage)
  (public_name gluten-mirage)
- (libraries faraday-lwt gluten-lwt lwt mirage-flow conduit-mirage cstruct)
+ (libraries faraday-lwt gluten-lwt lwt mirage-flow cstruct)
  (flags
   (:standard -safe-string)))

--- a/mirage/gluten_mirage.ml
+++ b/mirage/gluten_mirage.ml
@@ -35,13 +35,10 @@ open Lwt.Infix
 module Make_IO (Flow : Mirage_flow.S) :
   Gluten_lwt.IO with type socket = Flow.flow and type addr = unit = struct
   type socket = Flow.flow
-
   type addr = unit
 
   let shutdown flow = Flow.close flow
-
   let shutdown_receive flow = Lwt.async (fun () -> shutdown flow)
-
   let close = shutdown
 
   let read flow bigstring ~off ~len:_ =
@@ -49,11 +46,7 @@ module Make_IO (Flow : Mirage_flow.S) :
       (fun () ->
         Flow.read flow >|= function
         | Ok (`Data buf) ->
-          Bigstringaf.blit
-            buf.buffer
-            ~src_off:buf.off
-            bigstring
-            ~dst_off:off
+          Bigstringaf.blit buf.buffer ~src_off:buf.off bigstring ~dst_off:off
             ~len:buf.len;
           `Ok buf.len
         | Ok `Eof ->

--- a/mirage/gluten_mirage.mli
+++ b/mirage/gluten_mirage.mli
@@ -30,8 +30,12 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*)
 
+type 'a socket
+
+val create_socket : 'a -> 'a socket
+
 module Server (Flow : Mirage_flow.S) :
-  Gluten_lwt.Server with type socket = Flow.flow and type addr = unit
+  Gluten_lwt.Server with type socket = Flow.flow socket and type addr = unit
 
 module Client (Flow : Mirage_flow.S) :
-  Gluten_lwt.Client with type socket = Flow.flow
+  Gluten_lwt.Client with type socket = Flow.flow socket

--- a/mirage/gluten_mirage.mli
+++ b/mirage/gluten_mirage.mli
@@ -30,12 +30,19 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*)
 
-type 'a socket
+module Buffered_flow : sig
+  type 'a t = {
+    flow : 'a;
+    mutable buf : Cstruct.t;
+  }
 
-val create_socket : 'a -> 'a socket
+  val create : 'a -> 'a t
+end
 
 module Server (Flow : Mirage_flow.S) :
-  Gluten_lwt.Server with type socket = Flow.flow socket and type addr = unit
+  Gluten_lwt.Server
+    with type socket = Flow.flow Buffered_flow.t
+     and type addr = unit
 
 module Client (Flow : Mirage_flow.S) :
-  Gluten_lwt.Client with type socket = Flow.flow socket
+  Gluten_lwt.Client with type socket = Flow.flow Buffered_flow.t


### PR DESCRIPTION
This change fixes both the `read` and `writev` functions of the gluten-mirage package:

- `read` now respects the length parameter of the receiving buffer and if the received data is too large, it stores the rest of the data until the next read call.
- `writev` creates a copy of the data now, because the `Flow.writev` implementation takes ownership of the data buffers, and can't be reused.

The logic of `read` code has been confirmed in this thread: https://github.com/mirage/mirage-flow/issues/46#issuecomment-1194057006

The socket type of the `Client` and `Server` is not a pure `Mirage_flow.S.flow` anymore. Instead it must be created with `Gluten_mirage.create_socket flow`, with `flow` being a value of `Mirage_flow.S.flow`.