### PR TITLE
Fix memory leak

### DIFF
--- a/async/ssl_io.real.ml
+++ b/async/ssl_io.real.ml
@@ -61,8 +61,7 @@ module Io : Gluten_async_intf.IO with type 'a socket = 'a descriptor = struct
           iovecs
       in
       Writer.schedule_iovecs writer iovecs_q;
-      let pipe = Writer.pipe writer in
-      Pipe.downstream_flushed pipe >>| fun _ -> `Ok len
+      Writer.flushed writer >>| fun _ -> `Ok len
 
   (* From RFC8446§6.1:
    *   The client and the server must share knowledge that the connection is

--- a/async/tls_io.real.ml
+++ b/async/tls_io.real.ml
@@ -61,8 +61,7 @@ module Io : Gluten_async_intf.IO with type 'a socket = 'a descriptor = struct
           iovecs
       in
       Writer.schedule_iovecs writer iovecs_q;
-      let pipe = Writer.pipe writer in
-      Pipe.downstream_flushed pipe >>| fun _ -> `Ok len
+      Writer.flushed writer >>| fun _ -> `Ok len
 
   (* From RFC8446§6.1:
    *   The client and the server must share knowledge that the connection is


### PR DESCRIPTION
We observed a memory leak in long running-connections, traced to this code using memtrace. 

To give an indication, before the fix: 

![image](https://user-images.githubusercontent.com/22649114/211221113-f6e97ab9-82c6-4d8a-85eb-b96cfa71961d.png)

And a similar run after the fix: 

<img width="666" alt="image" src="https://user-images.githubusercontent.com/22649114/211221142-42e19349-e56d-4931-95ce-a241ca1d68e8.png">

Backporting on top of 0.3.0:

There's also a branch `fix/async-memory-leak-backport` which applies the fix on top of 0.3.0, which can be useful as a starting point for a possible 0.3.1 release.

If you create a branch starting from the 0.3.0 release (`12703c9`), I can open another PR to merge it there.
