### PR TITLE
async-tls compilation error when using tls-async package

### DIFF
--- a/async/tls_io.real.ml
+++ b/async/tls_io.real.ml
@@ -45,7 +45,9 @@ module Io : Gluten_async_intf.IO with type 'a socket = 'a descriptor = struct
 
   let read (reader, _, _) bigstring ~off ~len =
     let bigsubstr = Bigsubstring.create ~pos:off ~len bigstring in
-    Reader.read_bigsubstring reader bigsubstr
+    Reader.read_bigsubstring reader bigsubstr >>| function
+    | `Eof -> raise End_of_file
+    | `Ok n -> n
 
   let writev (_, writer, _) iovecs =
     match Writer.is_closed writer with


### PR DESCRIPTION
async-tls implementation did not match the interface when used with `tls-async` package installed. The dune rules select async/tls_io.real.ml rather than the dummy implementation in this case and you get the following error message.

```
# Error: Signature mismatch:
# [...]
#        Type
#          int Async.Reader.Read_result.t Async_unix__.Import.Deferred.t =
#            int Async.Reader.Read_result.t Async_kernel__Types.Deferred.t
#        is not compatible with type
#          int Async.Deferred.t = int Async_kernel__Types.Deferred.t 
#        Type int Async.Reader.Read_result.t = [ `Eof | `Ok of int ]
#        is not compatible with type int 
#        File "async/gluten_async_intf.ml", line 38, characters 2-78:
#          Expected declaration
#        File "async/tls_io.real.ml", line 46, characters 6-10:
#          Actual declaration
```

This fix unwraps the result type and converts it to an exception the same way `ssl_io_real.ml` does.