### PR TITLE
feat: replace `Gluten.Buffer` implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Unreleased
   raises an exception ([#61](https://github.com/anmonteiro/gluten/pull/61))
 - gluten-eio: handle peer disconnects
   ([#60](https://github.com/anmonteiro/gluten/pull/60))
+- gluten: replace `Gluten.Buffer` implementation and drop the `Ke` dependency
+  ([#67](https://github.com/anmonteiro/gluten/pull/67))
 
 0.4.1 2023-03-16
 --------------

--- a/dune-project
+++ b/dune-project
@@ -31,9 +31,7 @@
   (bigstringaf
    (>= "0.4.0"))
   (faraday
-   (>= "0.7.3"))
-  (ke
-   (>= "0.5"))))
+   (>= "0.7.3"))))
 
 (package
  (name gluten-lwt)

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1687178632,
-        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "lastModified": 1694857738,
+        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
         "type": "github"
       },
       "original": {
@@ -41,33 +41,32 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1693408407,
-        "narHash": "sha256-Pljd6L2PY8l8zr5VRL6gC/gfaLtIqEF6gZ3FCc8Cohc=",
+        "lastModified": 1697242648,
+        "narHash": "sha256-v+hB+l2BagkcSISry0SOLCv6QOkeJOd7ahLd22lrrUk=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "ad6a9535564fecba92b303d0dac17f69cff8672b",
+        "rev": "fc44ca77ef5bf3627483cf4113668980ea445f1a",
         "type": "github"
       },
       "original": {
         "owner": "nix-ocaml",
-        "ref": "anmonteiro/eio-0.12",
         "repo": "nix-overlays",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1693282374,
-        "narHash": "sha256-QZUxjv/MsWjradxgHlQFkP1ynR4BAuedY/Hs+gMyss8=",
+        "lastModified": 1697142613,
+        "narHash": "sha256-jplEwV6BqkvsqkhlWwHp/yrqTm0pKJ4l5VfEniTL6gs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d958404528cd939451ca2ed30473c3d7ae4d746",
+        "rev": "4183880e0e56f5a8dc55ef63df0cb64a7d5ea21f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d958404528cd939451ca2ed30473c3d7ae4d746",
+        "rev": "4183880e0e56f5a8dc55ef63df0cb64a7d5ea21f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.nix-filter.url = "github:numtide/nix-filter";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.inputs.flake-utils.follows = "flake-utils";
-  inputs.nixpkgs.url = "github:nix-ocaml/nix-overlays/anmonteiro/eio-0.12";
+  inputs.nixpkgs.url = "github:nix-ocaml/nix-overlays";
 
   outputs = { self, nixpkgs, flake-utils, nix-filter }:
     flake-utils.lib.eachDefaultSystem (system:

--- a/gluten.opam
+++ b/gluten.opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "bigstringaf" {>= "0.4.0"}
   "faraday" {>= "0.7.3"}
-  "ke" {>= "0.5"}
   "odoc" {with-doc}
 ]
 build: [

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name gluten)
  (public_name gluten)
- (libraries bigstringaf faraday ke))
+ (libraries bigstringaf faraday))


### PR DESCRIPTION
- gets rid of the `ke` dependency
- goes back to using the simpler Buffer implementation we had before, which seems to have a small edge in micro-benchmarks

benched with the help of https://github.com/chrstntdd/ocaml_http/pull/2