### PR TITLE
Don't require Unix in order to use mock sockets

### DIFF
--- a/eio/gluten_eio.mli
+++ b/eio/gluten_eio.mli
@@ -60,7 +60,7 @@ module Client : sig
     -> read_buffer_size:int
     -> protocol:'t Gluten.runtime
     -> 't
-    -> Eio_unix.Net.stream_socket_ty Eio.Net.stream_socket
+    -> _ Eio.Net.stream_socket
     -> t
 
   val upgrade : t -> Gluten.impl -> unit


### PR DESCRIPTION
Thanks for always being at the forefront and adapting to breaking changes in Eio's API!

After the Eio objects to variants migration, we weren't able to use an `Eio_mock.Net` network for tests anymore because commit 0c672bf386047e5ce88677f3e5dfc67b7e9c04d9 changed the socket type in the `Client` module from `Eio.Flow.two_way` to `Eio_unix.Net.stream_socket_ty Eio.Net.stream_socket`.

This is in contrast to the `Server` module where it's still `_ Eio.Net.stream_socket`.

As far as I can tell, there's no necessity for this restriction, so this PR changes it back and exposes `socket` as `Eio.Flow.two_way` again. (``[ `Generic ] Eio.Net.stream_socket_ty Eio.Net.stream_socket`` would also be possible and maybe more appropriate; I went with `two_way` because that's what it was before.)

However I don't know if there is any code that relies on it being Unix instead of the more generic type. I wasn't able to find any, but if this was a conscious choice maybe we can find a different way to allow for mock tests and still expose the socket (I refrained from adding a type parameter to `Client.t` for the network type but that would be one way, I guess).

If you think this is change feasible, there's a one-line change in `h2`, `httpaf` etc. needed as well so that they can also use mock networks again, along the lines of [this commit](https://github.com/dialohq/ocaml-h2/compare/a0e3f45..fc872de). I can open those PRs but they only make sense in conjunction with this one.