### PR TITLE
Lwt-unix: Fix file descriptor leak with `Lwt_unix.shutdown`

### DIFF
--- a/lwt-unix/gluten_lwt_unix.ml
+++ b/lwt-unix/gluten_lwt_unix.ml
@@ -42,11 +42,18 @@ module Io :
     match Lwt_unix.state socket with
     | Closed -> Lwt.return_unit
     | _ ->
-      Lwt.catch
+      Lwt.finalize
         (fun () ->
-           Lwt_unix.shutdown socket SHUTDOWN_ALL;
+           Lwt.catch
+             (fun () ->
+                Lwt_unix.shutdown socket SHUTDOWN_ALL;
+                Lwt.return_unit)
+             (function
+               |  Unix.Unix_error (Unix.ENOTCONN, _, _) -> Lwt.return_unit
+               |  exn -> Lwt.reraise exn))
+        (fun () -> 
            Lwt_unix.close socket)
-        (fun _exn -> Lwt.return_unit)
+
 
   let read socket bigstring ~off ~len =
     Lwt.catch


### PR DESCRIPTION
I stumbled across a case where the syscall `shutdown` of my application failed with `ENOTCONN` and the syscall to `close` did not occur resulting into a file descriptor leak.

By looking at the potential culprit, I found the shutdown function of this library.

The patch is inspired to what is done in [lwt_io](https://github.com/ocsigen/lwt/blob/master/src/unix/lwt_io.ml#L1540):

```ocaml
let close_socket fd =
  Lwt.finalize
    (fun () ->
       Lwt.catch
         (fun () ->
            Lwt_unix.shutdown fd Unix.SHUTDOWN_ALL;
            Lwt.return_unit)
         (function
           (* Occurs if the peer closes the connection first. *)
           | Unix.Unix_error (Unix.ENOTCONN, _, _) -> Lwt.return_unit
           | exn -> Lwt.reraise exn))
    (fun () ->
       Lwt_unix.close fd)
```

(for reference, another similar MR: https://github.com/ocsigen/lwt_ssl/pull/5)